### PR TITLE
docs: hide user api entry

### DIFF
--- a/docs/.vitepress/theme/constrants/route.ts
+++ b/docs/.vitepress/theme/constrants/route.ts
@@ -92,7 +92,6 @@ const items_xrobot_api = [
     collapsed: true,
     link: Chapters.xrobot_api,
     items: [
-      { text: "用户API", link: "user" },
       { text: "智能体API", link: "agent" },
       { text: "大语言模型API", link: "llm" },
       { text: "知识库API", link: "knowledge" },

--- a/docs/xrobot/api/index.md
+++ b/docs/xrobot/api/index.md
@@ -12,15 +12,13 @@ const chapter_root = Chapters.xrobot_api;
 
 **Base URL**: `https://xrobo.qiniu.com`
 
-**认证方式**: Bearer Token/API_Key
+**认证方式**: Bearer Token/API-KEY
 
 1. 所有API接口都需要有效的认证令牌
-2. 认证令牌格式为 `Bearer <token>`
+2. 开放API推荐使用 API-KEY，认证格式为 `Bearer <api_key>`
 
-    `<token>`有两种获取方式，推荐第一种：
+    `<api_key>` 在[灵矽AI控制台](https://xrobo.qiniu.com/#/api-key-management)创建。
 
-    - API-KEY: 在[灵矽AI控制台](https://xrobo.qiniu.com/#/api-key-management)创建 （推荐）
-    - [用户API - 登录](./user)
 
 ### 通用响应格式
 

--- a/docs/xrobot/api/user.md
+++ b/docs/xrobot/api/user.md
@@ -1,5 +1,6 @@
 ---
 title: 用户API文档
+search: false
 ---
 
 <script setup>


### PR DESCRIPTION
 官网用户api创建的账号创建不了apikey:对这个api文档下掉，避免误导用户，目前客户登录智控台用七牛账号就行