### PR TITLE
docs: 补充大模型 custom 参数说明与自助查询方法

### DIFF
--- a/docs/xrobot/api/agent.md
+++ b/docs/xrobot/api/agent.md
@@ -358,6 +358,64 @@ const updateAgentParameters = [
         description: '额外高级配置信息',
         children: [
           {
+            name: 'llm',
+            type: 'object',
+            required: false,
+            description: 'LLM 个性化配置。标准参数越界会被自动夹取到边界值（不报错）；custom_params 走模型 schema 校验，非法参数直接拒绝',
+            children: [
+              {
+                name: 'temperature',
+                type: 'number',
+                required: false,
+                description: '温度，控制输出随机性（接受范围 0.0~2.0，越界夹取）',
+                example: 0.7
+              },
+              {
+                name: 'top_p',
+                type: 'number',
+                required: false,
+                description: '核采样参数（接受范围 0.0~1.0，越界夹取）',
+                example: 1.0
+              },
+              {
+                name: 'frequency_penalty',
+                type: 'number',
+                required: false,
+                description: '频率惩罚（接受范围 -2.0~2.0，越界夹取）',
+                example: 0.0
+              },
+              {
+                name: 'max_tokens',
+                type: 'integer',
+                required: false,
+                description: '最长回复长度（接受范围 1~8192，越界夹取）',
+                example: 500
+              },
+              {
+                name: 'enable_search',
+                type: 'boolean',
+                required: false,
+                description: '是否联网搜索',
+                example: false
+              },
+              {
+                name: 'custom_params',
+                type: 'object',
+                required: false,
+                description: '大模型自定义参数，按所选 LLM 模型的 schema 校验，非法参数直接拒绝（400）。支持哪些参数取决于所选模型、且会随模型调整而变化，详见「大语言模型 API」文档',
+                children: [
+                  {
+                    name: 'body',
+                    type: 'object',
+                    required: false,
+                    description: '自定义参数键值对，key 与类型由所选模型的 schema 决定，接入前需先查询该模型 schema 再传',
+                    example: '{ "<自定义参数key>": "<按 schema 取值>" }'
+                  }
+                ]
+              }
+            ]
+          },
+          {
             name: 'voice',
             type: 'object',
             required: false,
@@ -443,6 +501,18 @@ Authorization: Bearer <token>
     }
   ],
   "extra": {
+    "llm": {
+      "temperature": 0.7,
+      "top_p": 1.0,
+      "frequency_penalty": 0.0,
+      "max_tokens": 500,
+      "enable_search": false,
+      "custom_params": {
+        "body": {
+          "<自定义参数key>": "<按 schema 取值>"
+        }
+      }
+    },
     "voice": {
       "speed": 1,
       "pitch": 1,
@@ -717,6 +787,10 @@ GET /xiaozhi/agent/list?limit=20&cursor=invalid-cursor
 
 ::: info
 更新智能体时，只需传递需要修改的字段，未传递的字段可以不传
+:::
+
+::: tip LLM 参数说明
+`extra.llm` 下的标准参数（temperature、top_p 等）越界会被自动夹取、不报错；`extra.llm.custom_params.body` 下的自定义参数会按所选模型的 schema 校验，非法参数直接拒绝。支持哪些自定义参数取决于所选模型、且会随模型调整而变化，具体 key/类型请以模型 schema 查询结果为准，详见 [大语言模型 API](./llm.md) 的「大模型自定义参数（custom_params）」一节。
 :::
 
 ### 删除智能体

--- a/docs/xrobot/api/llm.md
+++ b/docs/xrobot/api/llm.md
@@ -307,14 +307,21 @@ Authorization: Bearer <token>
 
 ### LLM个性化配置
 
-新增 `extra.llm` 字段用于个性化LLM配置，支持以下参数：
+新增 `extra.llm` 字段用于个性化LLM配置。这里的参数为**所有 LLM 模型通用的标准参数**，取值范围由后端统一定义、与具体模型无关，支持以下参数：
 
-| 参数 | 类型 | 说明 | 默认值 |
-|------|------|------|--------|
-| `temperature` | number | 控制输出的随机性（0.0-2.0） | 0.7 |
-| `top_p` | number | 核采样参数（0.0-1.0） | 0.9 |
-| `max_tokens` | integer | 最大输出令牌数 | 1024 |
-| `frequency_penalty` | number | 频率惩罚参数（-2.0-2.0） | 0.0 |
+| 参数 | 类型 | 说明 | 默认值 | 接受范围 |
+|------|------|------|--------|----------|
+| `temperature` | number | 控制输出的随机性 | 0.7 | 0.0 ~ 2.0 |
+| `top_p` | number | 核采样参数 | 1.0 | 0.0 ~ 1.0 |
+| `frequency_penalty` | number | 频率惩罚参数 | 0.0 | -2.0 ~ 2.0 |
+| `max_tokens` | integer | 最大输出令牌数（最长回复长度） | 500 | 1 ~ 8192 |
+| `enable_search` | boolean | 是否联网搜索 | false | true / false |
+
+::: warning 越界自动夹取，不报错
+标准参数即使传了超出范围的值（如 `temperature: 999`），后端也**不会拒绝请求**，而是**静默夹取**到边界值（如 `2.0`）。要精确生效请自行传合法值。这一行为与下文的自定义参数「非法即拒绝」不同。
+:::
+
+> 与模型相关、需按模型 schema 校验的参数（如 `thinking`、`reasoning_effort` 等），请通过 `custom_params` 传入，详见下文 **「七、大模型自定义参数（custom_params）」**。
 
 ### 请求示例
 
@@ -385,6 +392,157 @@ Authorization: Bearer <token>
 - `extra.llm` 配置参数将覆盖模型的默认配置
 - 建议在生产环境中对参数进行充分测试
 :::
+
+## 七、大模型自定义参数（custom_params）
+
+除上一节的通用标准参数外，部分模型还支持**与模型强相关的自定义参数**（如思考/推理控制 `thinking`、`reasoning_effort` 等）。这类参数通过 `extra.llm.custom_params` 传入，在保存 agent 配置时会按**该模型声明的 schema 做校验**，非法参数会被**直接拒绝**（不会像标准参数那样被夹取）。
+
+::: info 两类参数的区别
+| 类别 | 例子 | 传参位置 | 校验方式 | 越限 / 非法时 |
+|------|------|----------|----------|---------------|
+| **标准参数** | temperature、top_p、frequency_penalty、max_tokens、enable_search | `extra.llm.<key>` | 后端固定范围**夹取** | 夹到边界值，**不报错** |
+| **自定义参数** | thinking、reasoning_effort 等 | `extra.llm.custom_params.body.<key>` | 按**模型 schema** 白名单 + 类型校验 | **直接拒绝（400）** |
+:::
+
+### 传参位置
+
+自定义参数必须包在 `custom_params.body` 里：
+
+```json
+{
+  "extra": {
+    "llm": {
+      "custom_params": {
+        "body": {
+          "reasoning_effort": "high"
+        }
+      }
+    }
+  }
+}
+```
+
+### 校验规则
+
+保存 agent 配置时，后端按**该 agent 当前所选 LLM 模型**的 `custom_params_schema` 对 `body` 逐项校验：
+
+| 规则 | 说明 |
+|------|------|
+| **key 白名单** | `body` 里的 key 必须在该模型声明的范围内，否则拒绝：`非法的大模型自定义参数：<key>` |
+| **类型匹配** | 值的类型须与 schema 默认值类型一致（布尔 / 数字 / 字符串 / 对象 / 数组），否则拒绝：`大模型自定义参数 <key> 类型不合法` |
+| **不校验** | 取值范围、枚举值、整型 vs 浮点、嵌套子 key —— 这些由调用方自行保证 |
+| **无 schema / 空 `[]`** | 该模型**拒绝一切**自定义参数 |
+
+::: warning 只校验「是否合法 key」和「类型」，不校验取值内容
+例如 `reasoning_effort` 只校验它是字符串，**不校验**值是否在 `low / medium / high` 范围内。传了非法值平台会放行，但大模型侧调用时可能报错（400），需调用方自行保证取值合法。
+:::
+
+::: warning 支持哪些自定义参数由「所选模型」决定，请以查询结果为准
+平台可用的模型会动态调整，**本文不固定列出具体模型及其参数**。某个模型是否支持自定义参数、支持哪些 key、类型是什么，请在接入时通过 schema 接口**实时查询**（见下文「自定义参数 schema 从哪来」），不要在代码里写死。
+:::
+
+### 自定义参数的常见形态
+
+不同模型的自定义参数**没有统一的 key 和类型**——即便是同一类能力（如"是否开启思考/推理"），不同模型也可能用不同的 key、不同的值类型。常见形态如下（**仅为形态示例，实际 key 与类型请以模型 schema 为准**）：
+
+| 形态 | 值类型 | 传值示例 | 说明 |
+|------|--------|----------|------|
+| 布尔开关 | boolean | `true` / `false` | 直接开/关某项能力 |
+| 结构化对象 | object | `{ "type": "enabled" }` | 用对象字段做更细的控制 |
+| 枚举字符串 | string | `"low"` / `"medium"` / `"high"` | 以档位/等级取值 |
+
+::: warning 不要用同一个 key 套所有模型
+由于 key 和类型因模型而异，接入前请**按目标模型查它声明的确切 key 和类型**，再决定怎么传；换模型时需重新确认。
+
+### 请求示例
+
+以下为通用写法示例，`<llmModelId>` 填目标模型 ID，`body` 内的 key/值请以该模型 schema 为准：
+
+```http
+PUT /xiaozhi/agent/your-agent-id
+Content-Type: application/json
+Authorization: Bearer <token>
+```
+
+```json
+{
+  "llmModelId": "<llmModelId>",
+  "extra": {
+    "llm": {
+      "temperature": 0.7,
+      "top_p": 1.0,
+      "frequency_penalty": 0.0,
+      "max_tokens": 500,
+      "enable_search": false,
+      "custom_params": {
+        "body": {
+          "<自定义参数key>": "<按 schema 取值>"
+        }
+      }
+    }
+  }
+}
+```
+
+::: details 会被拒绝的例子（`<key>` 表示 body 里传入的自定义参数名）
+
+```jsonc
+// 1) key 不在该模型 schema 内
+{ "llmModelId": "<llmModelId>",
+  "extra": { "llm": { "custom_params": { "body": { "<未声明的key>": "..." } } } } }
+// → 400 非法的大模型自定义参数：<未声明的key>
+
+// 2) 类型不符（例如 schema 要求布尔，却传了字符串）
+{ "llmModelId": "<llmModelId>",
+  "extra": { "llm": { "custom_params": { "body": { "<key>": "true" } } } } }
+// → 400 大模型自定义参数 <key> 类型不合法
+
+// 3) 给「无 schema / 空 schema」的模型传自定义参数
+{ "llmModelId": "<llmModelId>",
+  "extra": { "llm": { "custom_params": { "body": { "<key>": "..." } } } } }
+// → 400 非法的大模型自定义参数：<key>
+```
+
+:::
+
+### 如何查询某模型支持的自定义参数
+
+平台可用的模型和它们支持的自定义参数会动态调整，**请在接入时自行查询、以查询结果为准，不要在代码里写死**。查询分两步（示例用 `curl`，`<token>` 替换为你的认证令牌）：
+
+**第一步：列出当前可用的 LLM 模型，拿到模型 `id`**
+
+```bash
+curl -s 'https://xrobo.qiniu.com/v1/agents/models/llm' \
+  -H 'Authorization: Bearer <token>'
+```
+
+返回中 `data.publics[]` / `data.privates[]` 每个元素的 `id` 即为模型 ID（接口详情见本文 **「五、获取LLM名称列表」**）。若装有 `jq`，可直接列出「id + 名称」：
+
+```bash
+curl -s 'https://xrobo.qiniu.com/v1/agents/models/llm' \
+  -H 'Authorization: Bearer <token>' \
+  | jq -r '.data.publics[], .data.privates[] | "\(.id)\t\(.name)"'
+```
+
+**第二步：用模型 `id` 查它当前声明的自定义参数 schema**
+
+```bash
+curl -s 'https://xrobo.qiniu.com/v1/models/<模型id>/custom-config-schema' \
+  -H 'Authorization: Bearer <token>'
+```
+
+返回的 schema 就是该模型**当前**支持的自定义参数（key / 类型 / 默认值），也是后端的校验白名单——即你能往 `custom_params.body` 里传哪些 key、每个 key 是什么类型的依据。
+
+::: tip 一步到位
+先取第一个模型的 id，再查它的 schema：
+
+```bash
+ID=$(curl -s 'https://xrobo.qiniu.com/v1/agents/models/llm' -H 'Authorization: Bearer <token>' | jq -r '.data.publics[0].id')
+curl -s "https://xrobo.qiniu.com/v1/models/$ID/custom-config-schema" -H 'Authorization: Bearer <token>' | jq .
+```
+:::
+
+> 说明：标准参数（第六节）的范围由后端固定，改代码才会变；自定义参数 schema 则随模型配置动态维护，务必以上述查询接口的实时结果为准。
 
 ## 相关文档
 

--- a/docs/xrobot/api/llm.md
+++ b/docs/xrobot/api/llm.md
@@ -453,7 +453,7 @@ Authorization: Bearer <token>
 
 ::: warning 不要用同一个 key 套所有模型
 由于 key 和类型因模型而异，接入前请**按目标模型查它声明的确切 key 和类型**，再决定怎么传；换模型时需重新确认。
-
+:::
 ### 请求示例
 
 以下为通用写法示例，`<llmModelId>` 填目标模型 ID，`body` 内的 key/值请以该模型 schema 为准：


### PR DESCRIPTION
- llm.md 新增「七、大模型自定义参数（custom_params）」：讲校验机制、参数常见形态、 两步 curl 自助查询 schema；不绑定具体模型
- 修正第六节标准参数表（top_p 默认 1.0、max_tokens 默认 500/范围 1~8192、新增 enable_search、 补越界夹取说明）
- agent.md 更新智能体接口补充 extra.llm.custom_params 参数结构、请求示例与说明