### PR TITLE
docs(api): 创建接口移除分离意图模式

### DIFF
--- a/docs/xrobot/api/agent.md
+++ b/docs/xrobot/api/agent.md
@@ -233,8 +233,8 @@ const createAgentParameters = [
         in: 'body',
         type: 'string',
         required: false,
-        description: '意图模型ID，不传时使用默认模板。无意图识别：Intent_nointent；分离意图识别：Intent_intent_llm；统一意图识别：Intent_function_call',
-        example: 'Intent_intent_llm'
+        description: '意图模型ID，不传时使用默认模板。无意图识别：Intent_nointent；统一意图识别：Intent_function_call',
+        example: 'Intent_function_call'
     }
 ]
 
@@ -247,7 +247,7 @@ Authorization: Bearer <token>
   "agentName": "客服助手",
   "assistantName": "助手阿伟",
   "llmModelId": "f3626c105383d71654a57f2bb8a973f3",
-  "intentModelId": "Intent_intent_llm"
+  "intentModelId": "Intent_function_call"
 }`
 
 const createAgentResponse = `{


### PR DESCRIPTION
## 变更内容

- 从创建智能体 API 的 `intentModelId` 说明中移除分离意图识别 `Intent_intent_llm`
- 将字段示例和创建请求示例统一调整为 `Intent_function_call`
- 保留无意图识别 `Intent_nointent` 和统一意图识别 `Intent_function_call` 两种公开取值

## 影响范围

仅修改官网创建智能体接口文档，不修改后端协议、运行时行为以及详情和更新接口文档。
