### PR TITLE
[docs] 新增声纹识别 V2 API 文档

### DIFF
--- a/docs/.vitepress/theme/constrants/route.ts
+++ b/docs/.vitepress/theme/constrants/route.ts
@@ -100,6 +100,7 @@ const items_xrobot_api = [
       { text: "设备工具描述API", link: "device-tool" },
       { text: "音色克隆API", link: "voice-clone" },
       { text: "长期记忆API", link: "longterm-memory" },
+      { text: "声纹识别V2 API", link: "voiceprint-v2" },
       { text: "获取语言列表API", link: "language" },
       { text: "其他API", link: "others" },
     ].map((item) => apply_prefix(item, Chapters.xrobot_api)),

--- a/docs/xrobot/api/voiceprint-v2.md
+++ b/docs/xrobot/api/voiceprint-v2.md
@@ -210,7 +210,7 @@ title: 声纹识别 V2 API
 ```
 
 ::: info 绑定说明
-`speaker_ids` 会按用户权限校验并自动去重。`voice_chat_only_enabled` 是只读的对话模式开关，如需修改请通过 [智能体 API](./agent.md) 更新智能体配置。
+`speaker_ids` 会按用户权限校验并自动去重。`voice_chat_only_enabled` 是只读开关：开启后，智能体只在识别到已绑定说话人时响应。如需修改请通过 [智能体 API](./agent.md) 更新智能体配置。
 :::
 
 ## 五、最近语音样本

--- a/docs/xrobot/api/voiceprint-v2.md
+++ b/docs/xrobot/api/voiceprint-v2.md
@@ -6,7 +6,7 @@ title: 声纹识别 V2 API
 
 ## 接口概述
 
-声纹识别 V2 以 **说话人（Speaker）** 为核心管理身份信息。一个说话人可以设置一条默认声纹，智能体通过 `speaker_ids` 选择本智能体需要识别的说话人。
+声纹识别 V2 以 **说话人（Speaker）** 为核心管理身份信息。一个说话人可以设置一条默认声纹；智能体需要绑定 `speaker_id` 后，才会识别该说话人。
 
 ::: warning 版本说明
 旧版 [声纹识别 API](./voice.md) 仍保留兼容，后续会逐步废弃。新接入和新配置流程建议使用本文档的 V2 接口。
@@ -115,7 +115,7 @@ title: 声纹识别 V2 API
 **请求方式：** `DELETE /v1/speakers/{speakerId}`
 
 ::: warning 删除限制
-如果说话人仍被智能体引用，需要先从对应智能体的说话人配置中移除。
+如果说话人仍被智能体引用，需要先从对应智能体的说话人绑定中移除。
 :::
 
 ## 三、声纹管理
@@ -166,11 +166,11 @@ title: 声纹识别 V2 API
 
 **请求方式：** `DELETE /v1/speakers/{speakerId}/voiceprint`
 
-## 四、智能体说话人配置
+## 四、智能体说话人绑定
 
-智能体说话人配置用于声明当前智能体需要识别哪些说话人。
+智能体说话人绑定用于维护当前智能体可识别的说话人。未绑定到智能体的说话人，不会参与该智能体的声纹识别。
 
-### 4.1 获取配置
+### 4.1 获取绑定
 
 **请求方式：** `GET /v1/agents/{agentId}/speaker-config`
 
@@ -189,7 +189,7 @@ title: 声纹识别 V2 API
 }
 ```
 
-### 4.2 更新配置
+### 4.2 更新绑定
 
 **请求方式：** `PUT /v1/agents/{agentId}/speaker-config`
 
@@ -197,7 +197,7 @@ title: 声纹识别 V2 API
 
 | 参数 | 类型 | 必填 | 说明 |
 |------|------|------|------|
-| `speaker_ids` | array | 否 | 说话人 ID 列表，传空数组表示清空 |
+| `speaker_ids` | array | 否 | 要绑定的说话人 ID 列表，传空数组表示清空绑定 |
 
 #### 请求示例
 
@@ -209,8 +209,8 @@ title: 声纹识别 V2 API
 }
 ```
 
-::: info 配置说明
-`speaker_ids` 会按用户权限校验并自动去重。`voice_chat_only_enabled` 是只读字段，如需修改请通过 [智能体 API](./agent.md) 更新智能体配置。
+::: info 绑定说明
+`speaker_ids` 会按用户权限校验并自动去重。`voice_chat_only_enabled` 是只读的对话模式开关，如需修改请通过 [智能体 API](./agent.md) 更新智能体配置。
 :::
 
 ## 五、最近语音样本
@@ -239,10 +239,10 @@ title: 声纹识别 V2 API
 
 ## 六、推荐接入流程
 
-1. 创建说话人。
-2. 从最近语音样本中选择一段清晰音频。
-3. 为说话人创建默认声纹。
-4. 将说话人绑定到智能体的 `speaker_ids`。
+1. 调用 `POST /v1/speakers` 创建说话人，保存返回的 `speaker_id`。
+2. 调用 `GET /v1/agents/{agentId}/chat-history`，从最近语音样本中选择一段清晰音频。
+3. 调用 `POST /v1/speakers/{speakerId}/voiceprint`，为说话人创建默认声纹。
+4. 调用 `PUT /v1/agents/{agentId}/speaker-config`，将 `speaker_id` 写入 `speaker_ids`。完成绑定后，该智能体才会识别该说话人。
 
 ## 相关文档
 

--- a/docs/xrobot/api/voiceprint-v2.md
+++ b/docs/xrobot/api/voiceprint-v2.md
@@ -1,0 +1,250 @@
+---
+title: 声纹识别 V2 API
+---
+
+# 声纹识别 V2 API
+
+## 接口概述
+
+声纹识别 V2 以 **说话人（Speaker）** 为核心管理身份信息。一个说话人可以设置一条默认声纹，智能体通过 `speaker_ids` 选择本智能体需要识别的说话人。
+
+::: warning 版本说明
+旧版 [声纹识别 API](./voice.md) 仍保留兼容，后续会逐步废弃。新接入和新配置流程建议使用本文档的 V2 接口。
+:::
+
+::: tip 使用说明
+本文档只描述软件侧配置接口。声纹处理由平台内部完成，公开接口不会返回声纹特征向量。
+:::
+
+## 一、基础信息
+
+**Base URL**: `https://xrobo.qiniu.com`
+
+**认证方式**: `Authorization: Bearer <token>`
+
+所有接口统一返回 HTTP 200，业务状态通过响应体中的 `code` 判断。
+
+```json
+{
+  "code": 0,
+  "reqid": "req_12345678",
+  "data": {}
+}
+```
+
+## 二、说话人管理
+
+### 2.1 创建说话人
+
+**请求方式：** `POST /v1/speakers`
+
+#### 参数说明
+
+| 参数 | 类型 | 必填 | 说明 |
+|------|------|------|------|
+| `name` | string | 是 | 说话人名称 |
+| `desc` | string | 否 | 说话人描述 |
+
+#### 请求示例
+
+```json
+{
+  "name": "妈妈",
+  "desc": "家庭成员"
+}
+```
+
+#### 响应示例
+
+```json
+{
+  "code": 0,
+  "reqid": "req_12345678",
+  "data": {
+    "speaker_id": "2f6c9f1f4d0f4a8ca3d9a7f6b8e2a123",
+    "name": "妈妈",
+    "desc": "家庭成员",
+    "created_at": "2026-08-05T10:00:00+08:00"
+  }
+}
+```
+
+### 2.2 获取说话人列表
+
+**请求方式：** `GET /v1/speakers`
+
+#### 响应示例
+
+```json
+{
+  "code": 0,
+  "reqid": "req_12345678",
+  "data": {
+    "speakers": [
+      {
+        "speaker_id": "2f6c9f1f4d0f4a8ca3d9a7f6b8e2a123",
+        "name": "妈妈",
+        "desc": "家庭成员",
+        "voiceprint_ids": [
+          "9e2b47d8f40945268f8a7b6e5d4c3b21"
+        ],
+        "created_at": "2026-08-05T10:00:00+08:00"
+      }
+    ]
+  }
+}
+```
+
+### 2.3 获取说话人详情
+
+**请求方式：** `GET /v1/speakers/{speakerId}`
+
+### 2.4 更新说话人
+
+**请求方式：** `PUT /v1/speakers/{speakerId}`
+
+#### 参数说明
+
+| 参数 | 类型 | 必填 | 说明 |
+|------|------|------|------|
+| `name` | string | 是 | 说话人名称 |
+| `desc` | string | 否 | 说话人描述 |
+
+### 2.5 删除说话人
+
+**请求方式：** `DELETE /v1/speakers/{speakerId}`
+
+::: warning 删除限制
+如果说话人仍被智能体引用，需要先从对应智能体的说话人配置中移除。
+:::
+
+## 三、声纹管理
+
+当前每个说话人维护一条默认声纹。重新创建声纹会替换旧声纹。
+
+### 3.1 创建或替换声纹
+
+**请求方式：** `POST /v1/speakers/{speakerId}/voiceprint`
+
+#### 参数说明
+
+| 参数 | 类型 | 必填 | 说明 |
+|------|------|------|------|
+| `audio_url` | string | 是 | 平台可访问的声纹样本音频 URL |
+| `source_device_id` | string | 否 | 采样来源设备 ID |
+
+#### 请求示例
+
+```json
+{
+  "audio_url": "https://example.com/sample.wav"
+}
+```
+
+#### 响应示例
+
+```json
+{
+  "code": 0,
+  "reqid": "req_12345678",
+  "data": {
+    "voiceprint_id": "9e2b47d8f40945268f8a7b6e5d4c3b21",
+    "audio_url": "https://example.com/sample.wav"
+  }
+}
+```
+
+::: tip 音频说明
+建议使用清晰、单人、无明显噪声的语音样本。平台会处理音频并保存声纹，接口响应不包含声纹特征向量。
+:::
+
+### 3.2 获取默认声纹
+
+**请求方式：** `GET /v1/speakers/{speakerId}/voiceprint`
+
+### 3.3 删除默认声纹
+
+**请求方式：** `DELETE /v1/speakers/{speakerId}/voiceprint`
+
+## 四、智能体说话人配置
+
+智能体说话人配置用于声明当前智能体需要识别哪些说话人。
+
+### 4.1 获取配置
+
+**请求方式：** `GET /v1/agents/{agentId}/speaker-config`
+
+#### 响应示例
+
+```json
+{
+  "code": 0,
+  "reqid": "req_12345678",
+  "data": {
+    "speaker_ids": [
+      "2f6c9f1f4d0f4a8ca3d9a7f6b8e2a123"
+    ],
+    "voice_chat_only_enabled": false
+  }
+}
+```
+
+### 4.2 更新配置
+
+**请求方式：** `PUT /v1/agents/{agentId}/speaker-config`
+
+#### 参数说明
+
+| 参数 | 类型 | 必填 | 说明 |
+|------|------|------|------|
+| `speaker_ids` | array | 否 | 说话人 ID 列表，传空数组表示清空 |
+
+#### 请求示例
+
+```json
+{
+  "speaker_ids": [
+    "2f6c9f1f4d0f4a8ca3d9a7f6b8e2a123"
+  ]
+}
+```
+
+::: info 配置说明
+`speaker_ids` 会按用户权限校验并自动去重。`voice_chat_only_enabled` 是只读字段，如需修改请通过 [智能体 API](./agent.md) 更新智能体配置。
+:::
+
+## 五、最近语音样本
+
+该接口仅用于辅助选择声纹样本，默认只返回当前智能体最近少量带音频的对话记录，不提供历史记录批量查询或导出能力。
+
+**请求方式：** `GET /v1/agents/{agentId}/chat-history`
+
+#### 响应示例
+
+以下示例仅展示创建声纹需要依赖的字段。
+
+```json
+{
+  "code": 0,
+  "reqid": "req_12345678",
+  "data": {
+    "records": [
+      {
+        "audio_url": "https://example.com/sample.wav"
+      }
+    ]
+  }
+}
+```
+
+## 六、推荐接入流程
+
+1. 创建说话人。
+2. 从最近语音样本中选择一段清晰音频。
+3. 为说话人创建默认声纹。
+4. 将说话人绑定到智能体的 `speaker_ids`。
+
+## 相关文档
+
+- [**声纹识别 API**](./voice.md) - 旧版声纹接口
+- [**智能体 API**](./agent.md) - 智能体配置接口


### PR DESCRIPTION
## Background
- xrobotd 声纹识别 V2 已落地为以 Speaker 为核心的软件侧配置接口，需要补充独立官方文档。
- 旧版声纹 API 文档继续保留兼容，后续逐步废弃；新接入和新配置流程使用 V2 文档。

## Changes
- 新增 `docs/xrobot/api/voiceprint-v2.md`，按公开软件接口说明 V2 接入方式。
- 在 API 侧边栏新增“声纹识别V2 API”入口。
- 覆盖公开契约：说话人管理、默认声纹管理、智能体说话人绑定、最近语音样本辅助选择。
- 明确使用路径：创建说话人、创建默认声纹、通过 `/v1/agents/{agentId}/speaker-config` 将 `speaker_id` 写入 `speaker_ids`；完成绑定后，该智能体才会识别该说话人。
- 收敛文档信息：不展开内部处理流程、内部运行时字段、底层能力入口、详细限制和错误表；`/v1/agents/{agentId}/chat-history` 仅说明为最近少量语音样本辅助接口，不作为历史记录批量查询或导出能力。

## Behavior Impact
- 仅文档变更，不影响线上接口、服务运行时或 SDK 行为。
- 旧版 `docs/xrobot/api/voice.md` 不做修改，新增 V2 文档供新流程使用。

## Risks and Rollback
- 风险主要是文档表述是否与最新代码保持一致。
- 如需回滚，可直接 revert 文档提交，不涉及数据或服务迁移。

## Verification
- 已对照 xrobotd 公开路由、API 结构和 e2e 封装确认接口路径与字段。
- `npm run docs:build`
- `git diff --check`
- 关键词扫查确认未暴露内部向量、底层能力入口、chat-history 查询参数、内部限制值等细节。

## Notes
- 集测变更结论：不需要。本次只修改 `xrobotd-doc` 文档，不改变 `xrobotd` 代码、协议实现、状态流转或运行时行为。