### PR TITLE
[docs] 隐藏声纹 API 文档入口

### DIFF
--- a/docs/.vitepress/theme/constrants/route.ts
+++ b/docs/.vitepress/theme/constrants/route.ts
@@ -100,7 +100,6 @@ const items_xrobot_api = [
       { text: "设备工具描述API", link: "device-tool" },
       { text: "音色克隆API", link: "voice-clone" },
       { text: "长期记忆API", link: "longterm-memory" },
-      { text: "声纹API", link: "voice" },
       { text: "获取语言列表API", link: "language" },
       { text: "其他API", link: "others" },
     ].map((item) => apply_prefix(item, Chapters.xrobot_api)),

--- a/docs/xrobot/api/voice.md
+++ b/docs/xrobot/api/voice.md
@@ -1,5 +1,6 @@
 ---
 title: 声纹识别 API
+search: false
 ---
 
 # 声纹识别 API

--- a/docs/xrobot/guide/voice-start.md
+++ b/docs/xrobot/guide/voice-start.md
@@ -302,7 +302,6 @@ curl -X POST "https://xrobo.qiniu.com/v1/voiceprint/voices/create" \
 
 ### 8.3 进阶学习资源
 
-- [声纹识别API文档](../api/voice.md) - 完整的API接口说明
 - [长期记忆最佳实践](./longterm-memory-start.md) - 用户身份与记忆关联
 
 ---


### PR DESCRIPTION
## 背景
当前声纹 API 文档内容与现行代码接口存在差异，先隐藏不展示。
## 改动
- 从 API 导航中移除声纹 API 入口。
- 设置 `search: false`，不纳入站内搜索。
- 移除最佳实践页面中的声纹 API 文档链接。