### PR TITLE
[docs] 隐藏智能体名称搜索选项

### DIFF
--- a/docs/xrobot/api/agent.md
+++ b/docs/xrobot/api/agent.md
@@ -68,29 +68,24 @@ const searchAgentParameters = [
     type: 'string',
     required: true,
     description: '搜索关键词',
-    example: '小智'
+    example: 'AA:BB:CC:DD:EE:FF'
   },
   {
     name: 'type',
     in: 'query',
     type: 'string',
-    required: false,
-    description: '搜索类型，支持 name（智能体名称）、mac（设备 MAC 地址）、agent_id（智能体 ID）。缺省默认为 name',
+    required: true,
+    description: '搜索类型，支持 mac（设备 MAC 地址）、agent_id（智能体 ID）',
     example: 'mac'
   }
 ]
 
-const searchAgentRequest = `// 示例 1：按名称前缀搜索（默认）
-GET /xiaozhi/agent/search?q=小智&type=name HTTP/1.1
-Host: https://xrobo.qiniu.com
-Authorization: Bearer <token>
-
-// 示例 2：按设备 MAC 地址精确搜索
+const searchAgentRequest = `// 示例 1：按设备 MAC 地址精确搜索
 GET /xiaozhi/agent/search?q=AA:BB:CC:DD:EE:FF&type=mac HTTP/1.1
 Host: https://xrobo.qiniu.com
 Authorization: Bearer <token>
 
-// 示例 3：按智能体 ID 精确搜索
+// 示例 2：按智能体 ID 精确搜索
 GET /xiaozhi/agent/search?q=4f3a8c7e0b6f4b5c9d3d0b8a2a1f0c9d&type=agent_id HTTP/1.1
 Host: https://xrobo.qiniu.com
 Authorization: Bearer <token>`
@@ -912,7 +907,7 @@ GET /xiaozhi/agent/list?limit=20&cursor=invalid-cursor
   endpoint="/agent/search"
   method="get"
   title="搜索智能体"
-  description="支持按名称前缀、设备 MAC 地址或智能体 ID 搜索智能体"
+  description="支持按设备 MAC 地址或智能体 ID 搜索智能体"
   :parameters="searchAgentParameters"
   :headers="getListHeaders"
   :requestExample="searchAgentRequest"
@@ -921,7 +916,6 @@ GET /xiaozhi/agent/list?limit=20&cursor=invalid-cursor
 />
 
 ::: tip 搜索类型与匹配规则
-- **name（智能体名称，默认）**：采用**前缀匹配**方式（SQL 逻辑等价于 `agent_name LIKE 'q%'`，例如搜索 `"小智"` 可命中 `"小智助手"`）
 - **mac（设备 MAC 地址）**：采用**精确匹配**，查询绑定该 MAC 设备且归属于当前用户的智能体
 - **agent_id（智能体 ID）**：采用**精确匹配**，按智能体 ID 查询归属于当前用户的智能体
 


### PR DESCRIPTION
### 背景

官网 API 文档当前公开了按智能体名称前缀搜索的能力。现调整对外展示口径，不再暴露 `name` 搜索类型。

### 改动

- 从搜索类型说明中移除 `name`，仅保留 `mac` 和 `agent_id`。
- 移除按智能体名称前缀搜索的请求示例与匹配规则。
- 将 `type` 标记为必填，避免省略后隐式使用名称搜索。
- 将搜索关键词示例调整为设备 MAC 地址。

### 行为变化（Behavior Impact）

| 维度 | 原先行为 | 现在行为（本次改动） |
| --- | --- | --- |
| 官网公开搜索类型 | `name`、`mac`、`agent_id` | `mac`、`agent_id` |
| `type` 文档约束 | 可选，默认 `name` | 必填，需明确指定搜索类型 |
| 后端接口行为 | 支持名称搜索 | 不变，本 PR 仅调整官网文档 |

### 风险与回滚

- 风险较低，仅影响官网文档展示，不涉及接口实现和数据变更。
- 回滚本 PR 即可恢复原文档说明。

### 验证

- `npm run docs:build`
- `git diff --check`

### Notes

- 本 PR 不修改后端对 `name` 搜索的实际支持，仅不再对外公开该能力。
- 仅文档变更，不需要调整 `integration/xrobot` 集成测试。